### PR TITLE
Added instruction for fixing USB port name

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,58 @@ ros2 launch aandd_ekew_driver_py bringup.launch.py use_fake:=True
 ros2 param set /aandd_ekew_node rate 1.2
 ```
 
+## fix the port name and add privilege(option)
+
+1. check vendor id and product id.
+
+   1. plug/unplug the usb cable in order to find the vendor id and product id of your device with `lsusb` command. For example, you can see the following text.
+      ```shell
+      Bus 004 Device 001: ID 1d6b:0003 Linux Foundation 3.0 root hub
+      Bus 003 Device 004: ID 04f2:b7c0 Chicony Electronics Co., Ltd Integrated Camera
+      Bus 003 Device 003: ID 06cb:00f9 Synaptics, Inc. 
+      Bus 003 Device 005: ID 8087:0033 Intel Corp. 
+      Bus 003 Device 007: ID 0584:b020 RATOC System, Inc. REX-USB60F
+      Bus 003 Device 001: ID 1d6b:0002 Linux Foundation 2.0 root hub
+      Bus 002 Device 001: ID 1d6b:0003 Linux Foundation 3.0 root hub
+      Bus 001 Device 001: ID 1d6b:0002 Linux Foundation 2.0 root hub
+      ```
+
+   2. hopefully you can find the new line. the example is the following.
+      ```
+      Bus 003 Device 007: ID 0584:b020 RATOC System, Inc. REX-USB60F
+      ```
+
+      The vendor id is `0584`, and product id is `b020`. **NOTE: This is example, the vendor id and product id depend on your device. It may be difference in your device.**
+
+2. change  value in `aandd_ekew_driver_py/99-weight-scale.rules` with your product id and product  id.
+
+   1. open rule file
+      ```shell
+      cd ros_ws/src/aandd_ekew_driver_py
+      vim 99-weight-scale.rules
+      ```
+
+   2. change values for `idVendor` and `idProduct`.
+      ```
+      SUBSYSTEM=="tty", ATTRS{idVendor}=="0584", ATTRS{idProduct}=="b020", SYMLINK+="weightscale", MODE="0666"
+      ```
+
+3. copy the rule file into `/etc/udev/rules.d/`
+   ```shell
+   sudo cp 99-weight-scale.rules /etc/udev/rules.d
+   ```
+
+4. enable your rule
+   ```shell
+   sudo udevadm control --reload
+   ```
+
+5. unplug and plug your usb cable. If the change is successful, you can find `/dev/weightscale`.
+
+6. change `port` to `weightscale` in `bringup.launch.py`.
+   ```
+   - port = launch.substitutions.LaunchConfiguration('port', default='/dev/ttyUSB0')
+   + port = launch.substitutions.LaunchConfiguration('port', default='/dev/weightscale')
+   ```
+
+   

--- a/README.md
+++ b/README.md
@@ -68,15 +68,15 @@ ros2 param set /aandd_ekew_node rate 1.2
 
       The vendor id is `0584`, and product id is `b020`. **NOTE: This is example, the vendor id and product id depend on your device. It may be difference in your device.**
 
-2. change  value in `aandd_ekew_driver_py/99-weight-scale.rules` with your product id and product  id.
+2. change  value in `aandd_ekew_driver_py/rules/99-weight-scale.rules` with your product id and product  id.
 
    1. open rule file
       ```shell
-      cd ros_ws/src/aandd_ekew_driver_py
+      cd ros_ws/src/aandd_ekew_driver_py/rules
       vim 99-weight-scale.rules
       ```
 
-   2. change values for `idVendor` and `idProduct`.
+   2. change values for `idVendor` and `idProduct`. If your vendor id is `0584` and product id is `b020`, edit it as below.
       ```
       SUBSYSTEM=="tty", ATTRS{idVendor}=="0584", ATTRS{idProduct}=="b020", SYMLINK+="weightscale", MODE="0666"
       ```

--- a/rules/99-weight-scale.rules
+++ b/rules/99-weight-scale.rules
@@ -1,0 +1,1 @@
+SUBSYSTEM=="tty", ATTRS{idVendor}=="0584", ATTRS{idProduct}=="b020", SYMLINK+="weightscale", MODE="0666"


### PR DESCRIPTION
## 概要
rulesを追加しました。接続時に作成されるポート名は`weightscale`になっています。
オプションという扱いにしたいので、launchファイル内でのポート名の設定はいじっていません。

## 変更点
- rulesディレクトリを追加
- rules/99-weight-scale.rulesを追加
- README.mdにdevice id&product idの確認方法と99-weight-scale.rulesの有効化に関する記述を追加

わかりにくい点・間違っているところなどありましたら、遠慮なく教えてください！