### PR TITLE
Changed launch file destination into launch dir

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
         ('share/ament_index/resource_index/packages',
             ['resource/' + package_name]),
         ('share/' + package_name, ['package.xml']),
-        (os.path.join('share', package_name), glob('launch/*.launch.py')),
+        (os.path.join('share', package_name, 'launch'), glob('launch/*.launch.py')),
     ],
     install_requires=['setuptools'],
     zip_safe=True,


### PR DESCRIPTION
# launchファイルのインストール先の修正

## 要約
`colcon build`したときのlaunchファイルのインストール先がパッケージ直下であり、launchディレクトリの中ではありませんでした。ROS2の慣習とあっていない気がしたので修正しました。

Before 
パッケージ直下にlaunchファイルがインストールされていました。
そのため、他のパッケージから使用するときは、下記のように呼び出す必要がありました。
```
weight_scale_launch_path = PathJoinSubstitution([FindPackageShare('aandd_ekew_driver_py'), 'bringup.launch.py'])
```

After
パッケージ/launch/以下にlaunchファイルがインストールされるようになります。
そのため、下記のように他の多くのパッケージと同じような書き方ができるようになります。
```
weight_scale_launch_path = PathJoinSubstitution([FindPackageShare('aandd_ekew_driver_py'), 'launch', 'bringup.launch.py'])
```